### PR TITLE
Suppress compiler warning [-Wpointer-sign]

### DIFF
--- a/src/pack.c
+++ b/src/pack.c
@@ -1029,7 +1029,7 @@ mrb_pack_unpack(mrb_state *mrb, mrb_value str)
       continue;
 
     if (flags & PACK_FLAG_COUNT2) {
-      sptr = RSTRING_PTR(str) + srcidx;
+      sptr = (const unsigned char *)RSTRING_PTR(str) + srcidx;
       switch (dir) {
       case PACK_DIR_HEX:
         srcidx += unpack_h(mrb, sptr, srclen - srcidx, result, count, flags);
@@ -1049,7 +1049,7 @@ mrb_pack_unpack(mrb_state *mrb, mrb_value str)
         break;
       }
 
-      sptr = RSTRING_PTR(str) + srcidx;
+      sptr = (const unsigned char *)RSTRING_PTR(str) + srcidx;
       switch (dir) {
       case PACK_DIR_CHAR:
         srcidx += unpack_c(mrb, sptr, srclen - srcidx, result, flags);


### PR DESCRIPTION
On OSX clang v7.3.0 appear these warning.

```
...
CC    ../mruby-pack/src/pack.c -> build/test/mrbgems/mruby-pack/src/pack.o
/Users/yuki/src/github.com/ksss/mruby-pack/src/pack.c:1032:12: warning: assigning to 'const unsigned char *' from 'char *' converts
      between pointers to integer types with different sign [-Wpointer-sign]
      sptr = RSTRING_PTR(str) + srcidx;
           ^ ~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/yuki/src/github.com/ksss/mruby-pack/src/pack.c:1052:12: warning: assigning to 'const unsigned char *' from 'char *' converts
      between pointers to integer types with different sign [-Wpointer-sign]
      sptr = RSTRING_PTR(str) + srcidx;
           ^ ~~~~~~~~~~~~~~~~~~~~~~~~~
2 warnings generated.
...
```