### PR TITLE
Support unpack template "U"

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ There is no dependency on other mrbgems.
  - q : 64-bit signed, native endian (`int64_t`)
  - S : 16-bit unsigned, native endian (`uint16_t`)
  - s : 16-bit signed, native endian (`int16_t`)
+ - U : UTF-8 character
  - V : 32-bit unsigned, VAX (little-endian) byte order
  - v : 16-bit unsigned, VAX (little-endian) byte order
  - x : null byte

--- a/test/pack.rb
+++ b/test/pack.rb
@@ -145,3 +145,17 @@ assert 'pack/unpack "I"' do
   end
   assert_pack 'I', str, [12345]
 end
+
+assert 'pack/unpack "U"' do
+  assert_equal [], "".unpack("U")
+  assert_equal [], "".unpack("U*")
+  assert_equal [65, 66], "ABC".unpack("U2")
+  assert_equal [12371, 12435, 12395, 12385, 12399, 19990, 30028], "こんにちは世界".unpack("U*")
+
+  assert_equal "", [].pack("U")
+  assert_equal "", [].pack("U*")
+  assert_equal "AB", [65, 66, 67].pack("U2")
+  assert_equal "こんにちは世界", [12371, 12435, 12395, 12385, 12399, 19990, 30028].pack("U*")
+
+  assert_equal "\000", [0].pack("U")
+end

--- a/test/pack.rb
+++ b/test/pack.rb
@@ -158,4 +158,8 @@ assert 'pack/unpack "U"' do
   assert_equal "こんにちは世界", [12371, 12435, 12395, 12385, 12399, 19990, 30028].pack("U*")
 
   assert_equal "\000", [0].pack("U")
+
+  assert_raise(RangeError) { [-0x40000000].pack("U") }
+  assert_raise(RangeError) { [-1].pack("U") }
+  assert_raise(RangeError) { [0x40000000].pack("U") }
 end


### PR DESCRIPTION
I implemented unpack "U" template.

The testing passed both defined `MRB_UTF8_STRING` or not.

Refs:

https://github.com/iij/mruby-pack/issues/12
https://github.com/iij/mruby-pack/pull/10